### PR TITLE
Fixed an issue when modifying a message

### DIFF
--- a/src/Wumpus.Net.Rest/Requests/Messages/ModifyMessageParams.cs
+++ b/src/Wumpus.Net.Rest/Requests/Messages/ModifyMessageParams.cs
@@ -18,7 +18,7 @@ namespace Wumpus.Requests
         {
             if (!Content.IsSpecified || Content.Value is null)
                 Content = (Utf8String)"";
-            if (Embed.IsSpecified && Embed.Value != null)
+            if (!Embed.IsSpecified && Content.Value is null)
                 Preconditions.NotNullOrWhitespace(Content, nameof(Content));
             // else //TODO: Validate embed length
             Preconditions.LengthAtMost(Content, Message.MaxContentLength, nameof(Content));

--- a/src/Wumpus.Net.Rest/Requests/Messages/ModifyMessageParams.cs
+++ b/src/Wumpus.Net.Rest/Requests/Messages/ModifyMessageParams.cs
@@ -18,7 +18,7 @@ namespace Wumpus.Requests
         {
             if (!Content.IsSpecified || Content.Value is null)
                 Content = (Utf8String)"";
-            if (!Embed.IsSpecified && Content.Value is null)
+            if (!Embed.IsSpecified && Content == (Utf8String)"")
                 Preconditions.NotNullOrWhitespace(Content, nameof(Content));
             // else //TODO: Validate embed length
             Preconditions.LengthAtMost(Content, Message.MaxContentLength, nameof(Content));

--- a/src/Wumpus.Net.Rest/Requests/Messages/ModifyMessageParams.cs
+++ b/src/Wumpus.Net.Rest/Requests/Messages/ModifyMessageParams.cs
@@ -18,7 +18,7 @@ namespace Wumpus.Requests
         {
             if (!Content.IsSpecified || Content.Value is null)
                 Content = (Utf8String)"";
-            if (!Embed.IsSpecified && Content == (Utf8String)"")
+            if (!Embed.IsSpecified || Embed.Value == null)
                 Preconditions.NotNullOrWhitespace(Content, nameof(Content));
             // else //TODO: Validate embed length
             Preconditions.LengthAtMost(Content, Message.MaxContentLength, nameof(Content));


### PR DESCRIPTION
When calling modify on a message if the content wasn't specified but an embed was it'd throw a content can't be empty exception