### PR TITLE
Fix #11, Implement setting X-Audit-Log-Reason header

### DIFF
--- a/src/Wumpus.Net.Rest/Net/IDiscordRestApi.cs
+++ b/src/Wumpus.Net.Rest/Net/IDiscordRestApi.cs
@@ -43,9 +43,9 @@ namespace Wumpus.Net
         ///     If modifying a category, individual Channel Update events will fire for each child channel that also changes.
         /// </summary>
         [Patch("channels/{channelId}")]
-        Task<Channel> ModifyChannelAsync([Path] Snowflake channelId, [Body] ModifyChannelParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
+        Task<Channel> ModifyChannelAsync([Path] Snowflake channelId, [Body] ModifyChannelParams args, [Header(WumpusRestClient.ReasonHeader)] Utf8String reason = null);
         [Delete("channels/{channelId}")]
-        Task<Channel> DeleteChannelAsync([Path] Snowflake channelId, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
+        Task<Channel> DeleteChannelAsync([Path] Snowflake channelId, [Header(WumpusRestClient.ReasonHeader)] Utf8String reason = null);
 
         /// <summary>
         ///     Returns the <see cref="Entities.Message"/> for a <see cref="Entities.Channel"/>. If operating on a <see cref="Entities.Guild"/> <see cref="Entities.Channel"/>, this endpoint requires the <see cref="Entities.ChannelPermissions.ViewChannel"/> to be present on the current <see cref="Entities.User"/>.
@@ -68,7 +68,7 @@ namespace Wumpus.Net
         [Patch("channels/{channelId}/messages/{messageId}")]
         Task<Message> ModifyMessageAsync([Path] Snowflake channelId, [Path] Snowflake messageId, [Body] ModifyMessageParams args);
         [Delete("channels/{channelId}/messages/{messageId}")]
-        Task DeleteMessageAsync([Path] Snowflake channelId, [Path] Snowflake messageId, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
+        Task DeleteMessageAsync([Path] Snowflake channelId, [Path] Snowflake messageId, [Header(WumpusRestClient.ReasonHeader)] Utf8String reason = null);
         [Post("channels/{channelId}/messages/bulk-delete")]
         Task DeleteMessagesAsync([Path] Snowflake channelId, [Body] DeleteMessagesParams args);
 
@@ -84,9 +84,9 @@ namespace Wumpus.Net
         Task DeleteAllReactionsAsync([Path] Snowflake channelId, [Path] Snowflake messageId);
 
         [Put("channels/{channelId}/permissions/{overwriteId}")]
-        Task EditChannelPermissionsAsync([Path] Snowflake channelId, [Path] Snowflake overwriteId, [Body] ModifyChannelPermissionsParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
+        Task EditChannelPermissionsAsync([Path] Snowflake channelId, [Path] Snowflake overwriteId, [Body] ModifyChannelPermissionsParams args, [Header(WumpusRestClient.ReasonHeader)] Utf8String reason = null);
         [Delete("channels/{channelId}/permissions/{overwriteId}")]
-        Task DeleteChannelPermissionsAsync([Path] Snowflake channelId, [Path] Snowflake overwriteId, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
+        Task DeleteChannelPermissionsAsync([Path] Snowflake channelId, [Path] Snowflake overwriteId, [Header(WumpusRestClient.ReasonHeader)] Utf8String reason = null);
 
         [Get("channels/{channelId}/invites")]
         Task<Invite[]> GetChannelInvitesAsync([Path] Snowflake channelId);
@@ -115,11 +115,11 @@ namespace Wumpus.Net
         [Get("guilds/{guildId}/emoji/{emojiId}")]
         Task<Emoji> GetGuildEmojiAsync([Path] Snowflake guildId, [Path] Snowflake emojiId);
         [Post("guilds/{guildId}/emojis")]
-        Task<Emoji> CreateGuildEmojiAsync([Path] Snowflake guildId, [Body] CreateGuildEmojiParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
+        Task<Emoji> CreateGuildEmojiAsync([Path] Snowflake guildId, [Body] CreateGuildEmojiParams args, [Header(WumpusRestClient.ReasonHeader)] Utf8String reason = null);
         [Patch("guilds/{guildId}/emoji/{emojiId}")]
-        Task<Emoji> ModifyGuildEmojiAsync([Path] Snowflake guildId, [Path] Snowflake emojiId, [Body] ModifyGuildEmojiParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
+        Task<Emoji> ModifyGuildEmojiAsync([Path] Snowflake guildId, [Path] Snowflake emojiId, [Body] ModifyGuildEmojiParams args, [Header(WumpusRestClient.ReasonHeader)] Utf8String reason = null);
         [Delete("guilds/{guildId}/emoji/{emojiId}")]
-        Task DeleteGuildEmojiAsync([Path] Snowflake guildId, [Path] Snowflake emojiId, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
+        Task DeleteGuildEmojiAsync([Path] Snowflake guildId, [Path] Snowflake emojiId, [Header(WumpusRestClient.ReasonHeader)] Utf8String reason = null);
 
         // Gateway
 
@@ -135,14 +135,14 @@ namespace Wumpus.Net
         [Post("guilds")]
         Task<Guild> CreateGuildAsync([Body] CreateGuildParams args);
         [Patch("guilds/{guildId}")]
-        Task<Guild> ModifyGuildAsync([Path] Snowflake guildId, [Body] ModifyGuildParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
+        Task<Guild> ModifyGuildAsync([Path] Snowflake guildId, [Body] ModifyGuildParams args, [Header(WumpusRestClient.ReasonHeader)] Utf8String reason = null);
         [Delete("guilds/{guildId}")]
         Task DeleteGuildAsync([Path] Snowflake guildId);
 
         [Get("guilds/{guildId}/channels")]
         Task<Channel[]> GetGuildChannelsAsync([Path] Snowflake guildId);
         [Post("guilds/{guildId}/channels")]
-        Task<Channel> CreateGuildChannelAsync([Path] Snowflake guildId, [Body] CreateGuildChannelParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
+        Task<Channel> CreateGuildChannelAsync([Path] Snowflake guildId, [Body] CreateGuildChannelParams args, [Header(WumpusRestClient.ReasonHeader)] Utf8String reason = null);
         [Patch("guilds/{guildId}/channels")]
         Task<Channel[]> ModifyGuildChannelPositionsAsync([Path] Snowflake guildId, [Body] ModifyGuildChannelPositionParams[] args);
 
@@ -153,7 +153,7 @@ namespace Wumpus.Net
         [Put("guilds/{guildId}/members/{userId}")]
         Task<GuildMember> AddGuildMemberAsync([Path] Snowflake guildId, [Path] Snowflake userId, [Body] AddGuildMemberParams args);
         [Delete("guilds/{guildId}/members/{userId}")]
-        Task RemoveGuildMemberAsync([Path] Snowflake guildId, [Path] Snowflake userId, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
+        Task RemoveGuildMemberAsync([Path] Snowflake guildId, [Path] Snowflake userId, [Header(WumpusRestClient.ReasonHeader)] Utf8String reason = null);
         [Patch("guilds/{guildId}/members/{userId}")]
         Task ModifyGuildMemberAsync([Path] Snowflake guildId, [Path] Snowflake userId, [Body] ModifyGuildMemberParams args);
         [Patch("guilds/{guildId}/members/@me/nick")]
@@ -167,25 +167,25 @@ namespace Wumpus.Net
         [Get("guilds/{guildId}/bans")]
         Task<Ban[]> GetGuildBansAsync([Path] Snowflake guildId);
         [Put("guilds/{guildId}/bans/{userId}")]
-        Task CreateGuildBanAsync([Path] Snowflake guildId, [Path] Snowflake userId, [QueryMap] CreateGuildBanParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
+        Task CreateGuildBanAsync([Path] Snowflake guildId, [Path] Snowflake userId, [QueryMap] CreateGuildBanParams args, [Header(WumpusRestClient.ReasonHeader)] Utf8String reason = null);
         [Delete("guilds/{guildId}/bans/{userId}")]
-        Task DeleteGuildBanAsync([Path] Snowflake guildId, [Path] Snowflake userId, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
+        Task DeleteGuildBanAsync([Path] Snowflake guildId, [Path] Snowflake userId, [Header(WumpusRestClient.ReasonHeader)] Utf8String reason = null);
 
         [Get("guilds/{guildId}/roles")]
         Task<Role[]> GetGuildRolesAsync([Path] Snowflake guildId);
         [Post("guilds/{guildId}/roles")]
-        Task<Role> CreateGuildRoleAsync([Path] Snowflake guildId, [Body] CreateGuildRoleParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
+        Task<Role> CreateGuildRoleAsync([Path] Snowflake guildId, [Body] CreateGuildRoleParams args, [Header(WumpusRestClient.ReasonHeader)] Utf8String reason = null);
         [Delete("guilds/{guildId}/roles/{roleId}")]
-        Task<Role> DeleteGuildRoleAsync([Path] Snowflake guildId, [Path] Snowflake roleId, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
+        Task<Role> DeleteGuildRoleAsync([Path] Snowflake guildId, [Path] Snowflake roleId, [Header(WumpusRestClient.ReasonHeader)] Utf8String reason = null);
         [Patch("guilds/{guildId}/roles/{roleId}")]
-        Task<Role> ModifyGuildRoleAsync([Path] Snowflake guildId, [Path] Snowflake roleId, [Body] ModifyGuildRoleParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
+        Task<Role> ModifyGuildRoleAsync([Path] Snowflake guildId, [Path] Snowflake roleId, [Body] ModifyGuildRoleParams args, [Header(WumpusRestClient.ReasonHeader)] Utf8String reason = null);
         [Patch("guilds/{guildId}/roles")]
         Task ModifyGuildRolePositionsAsync([Path] Snowflake guildId, [Body] ModifyGuildRolePositionParams[] args);
 
         [Get("guilds/{guildId}/prune")]
         Task<GuildPruneCountResponse> GetGuildPruneCountAsync([Path] Snowflake guildId, [QueryMap] GuildPruneParams args);
         [Post("guilds/{guildId}/prune")]
-        Task<GuildPruneCountResponse> PruneGuildMembersAsync([Path] Snowflake guildId, [QueryMap] GuildPruneParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
+        Task<GuildPruneCountResponse> PruneGuildMembersAsync([Path] Snowflake guildId, [QueryMap] GuildPruneParams args, [Header(WumpusRestClient.ReasonHeader)] Utf8String reason = null);
 
         [Get("guilds/{guildId}/regions")]
         Task<VoiceRegion[]> GetGuildVoiceRegionsAsync([Path] Snowflake guildId);
@@ -217,7 +217,7 @@ namespace Wumpus.Net
         [Get("invites/{code}")]
         Task<Invite> GetInviteAsync([Path] Utf8String code, [QueryMap] GetInviteParams args);
         [Delete("invites/{code}")]
-        Task<Invite> DeleteInviteAsync([Path] Utf8String code, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
+        Task<Invite> DeleteInviteAsync([Path] Utf8String code, [Header(WumpusRestClient.ReasonHeader)] Utf8String reason = null);
 
         // OAuth
 
@@ -265,19 +265,19 @@ namespace Wumpus.Net
         Task<Webhook> GetWebhookAsync([Path] Snowflake webhookId, [Path] Utf8String webhookToken);
 
         [Post("channels/{channelId}/webhooks")]
-        Task<Webhook> CreateWebhookAsync([Path] Snowflake channelId, [Body] CreateWebhookParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
+        Task<Webhook> CreateWebhookAsync([Path] Snowflake channelId, [Body] CreateWebhookParams args, [Header(WumpusRestClient.ReasonHeader)] Utf8String reason = null);
 
         [Delete("webhooks/{webhookId}")]
-        Task DeleteWebhookAsync([Path] Snowflake webhookId, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
+        Task DeleteWebhookAsync([Path] Snowflake webhookId, [Header(WumpusRestClient.ReasonHeader)] Utf8String reason = null);
         [Delete("webhooks/{webhookId}/{webhookToken}")]
         [Header("Authorization", null)]
-        Task DeleteWebhookAsync([Path] Snowflake webhookId, [Path] Utf8String webhookToken, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
+        Task DeleteWebhookAsync([Path] Snowflake webhookId, [Path] Utf8String webhookToken, [Header(WumpusRestClient.ReasonHeader)] Utf8String reason = null);
 
         [Patch("webhooks/{webhookId}")]
-        Task<Webhook> ModifyWebhookAsync([Path] Snowflake webhookId, ModifyWebhookParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
+        Task<Webhook> ModifyWebhookAsync([Path] Snowflake webhookId, ModifyWebhookParams args, [Header(WumpusRestClient.ReasonHeader)] Utf8String reason = null);
         [Patch("webhooks/{webhookId}/{webhookToken}")]
         [Header("Authorization", null)]
-        Task<Webhook> ModifyWebhookAsync([Path] Snowflake webhookId, [Path] Utf8String webhookToken, ModifyWebhookParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
+        Task<Webhook> ModifyWebhookAsync([Path] Snowflake webhookId, [Path] Utf8String webhookToken, ModifyWebhookParams args, [Header(WumpusRestClient.ReasonHeader)] Utf8String reason = null);
 
         [Post("webhooks/{webhookId}/{webhookToken}")]
         [Header("Authorization", null)]

--- a/src/Wumpus.Net.Rest/Net/IDiscordRestApi.cs
+++ b/src/Wumpus.Net.Rest/Net/IDiscordRestApi.cs
@@ -68,7 +68,7 @@ namespace Wumpus.Net
         [Patch("channels/{channelId}/messages/{messageId}")]
         Task<Message> ModifyMessageAsync([Path] Snowflake channelId, [Path] Snowflake messageId, [Body] ModifyMessageParams args);
         [Delete("channels/{channelId}/messages/{messageId}")]
-        Task DeleteMessageAsync([Path] Snowflake channelId, [Path] Snowflake messageId, [Header(WumpusRestClient.ReasonHeader)] string reason = null); // TODO: validate X-Audit-Log-Reason 0-512 chars
+        Task DeleteMessageAsync([Path] Snowflake channelId, [Path] Snowflake messageId, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
         [Post("channels/{channelId}/messages/bulk-delete")]
         Task DeleteMessagesAsync([Path] Snowflake channelId, [Body] DeleteMessagesParams args);
 

--- a/src/Wumpus.Net.Rest/Net/IDiscordRestApi.cs
+++ b/src/Wumpus.Net.Rest/Net/IDiscordRestApi.cs
@@ -43,9 +43,9 @@ namespace Wumpus.Net
         ///     If modifying a category, individual Channel Update events will fire for each child channel that also changes.
         /// </summary>
         [Patch("channels/{channelId}")]
-        Task<Channel> ModifyChannelAsync([Path] Snowflake channelId, [Body] ModifyChannelParams args);
+        Task<Channel> ModifyChannelAsync([Path] Snowflake channelId, [Body] ModifyChannelParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
         [Delete("channels/{channelId}")]
-        Task<Channel> DeleteChannelAsync([Path] Snowflake channelId);
+        Task<Channel> DeleteChannelAsync([Path] Snowflake channelId, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
 
         /// <summary>
         ///     Returns the <see cref="Entities.Message"/> for a <see cref="Entities.Channel"/>. If operating on a <see cref="Entities.Guild"/> <see cref="Entities.Channel"/>, this endpoint requires the <see cref="Entities.ChannelPermissions.ViewChannel"/> to be present on the current <see cref="Entities.User"/>.
@@ -68,7 +68,7 @@ namespace Wumpus.Net
         [Patch("channels/{channelId}/messages/{messageId}")]
         Task<Message> ModifyMessageAsync([Path] Snowflake channelId, [Path] Snowflake messageId, [Body] ModifyMessageParams args);
         [Delete("channels/{channelId}/messages/{messageId}")]
-        Task DeleteMessageAsync([Path] Snowflake channelId, [Path] Snowflake messageId);
+        Task DeleteMessageAsync([Path] Snowflake channelId, [Path] Snowflake messageId, [Header(WumpusRestClient.ReasonHeader)] string reason = null); // TODO: validate X-Audit-Log-Reason 0-512 chars
         [Post("channels/{channelId}/messages/bulk-delete")]
         Task DeleteMessagesAsync([Path] Snowflake channelId, [Body] DeleteMessagesParams args);
 
@@ -84,9 +84,9 @@ namespace Wumpus.Net
         Task DeleteAllReactionsAsync([Path] Snowflake channelId, [Path] Snowflake messageId);
 
         [Put("channels/{channelId}/permissions/{overwriteId}")]
-        Task EditChannelPermissionsAsync([Path] Snowflake channelId, [Path] Snowflake overwriteId, [Body] ModifyChannelPermissionsParams args);
+        Task EditChannelPermissionsAsync([Path] Snowflake channelId, [Path] Snowflake overwriteId, [Body] ModifyChannelPermissionsParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
         [Delete("channels/{channelId}/permissions/{overwriteId}")]
-        Task DeleteChannelPermissionsAsync([Path] Snowflake channelId, [Path] Snowflake overwriteId);
+        Task DeleteChannelPermissionsAsync([Path] Snowflake channelId, [Path] Snowflake overwriteId, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
 
         [Get("channels/{channelId}/invites")]
         Task<Invite[]> GetChannelInvitesAsync([Path] Snowflake channelId);
@@ -115,11 +115,11 @@ namespace Wumpus.Net
         [Get("guilds/{guildId}/emoji/{emojiId}")]
         Task<Emoji> GetGuildEmojiAsync([Path] Snowflake guildId, [Path] Snowflake emojiId);
         [Post("guilds/{guildId}/emojis")]
-        Task<Emoji> CreateGuildEmojiAsync([Path] Snowflake guildId, [Body] CreateGuildEmojiParams args);
+        Task<Emoji> CreateGuildEmojiAsync([Path] Snowflake guildId, [Body] CreateGuildEmojiParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
         [Patch("guilds/{guildId}/emoji/{emojiId}")]
-        Task<Emoji> ModifyGuildEmojiAsync([Path] Snowflake guildId, [Path] Snowflake emojiId, [Body] ModifyGuildEmojiParams args);
+        Task<Emoji> ModifyGuildEmojiAsync([Path] Snowflake guildId, [Path] Snowflake emojiId, [Body] ModifyGuildEmojiParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
         [Delete("guilds/{guildId}/emoji/{emojiId}")]
-        Task DeleteGuildEmojiAsync([Path] Snowflake guildId, [Path] Snowflake emojiId);
+        Task DeleteGuildEmojiAsync([Path] Snowflake guildId, [Path] Snowflake emojiId, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
 
         // Gateway
 
@@ -135,14 +135,14 @@ namespace Wumpus.Net
         [Post("guilds")]
         Task<Guild> CreateGuildAsync([Body] CreateGuildParams args);
         [Patch("guilds/{guildId}")]
-        Task<Guild> ModifyGuildAsync([Path] Snowflake guildId, [Body] ModifyGuildParams args);
+        Task<Guild> ModifyGuildAsync([Path] Snowflake guildId, [Body] ModifyGuildParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
         [Delete("guilds/{guildId}")]
         Task DeleteGuildAsync([Path] Snowflake guildId);
 
         [Get("guilds/{guildId}/channels")]
         Task<Channel[]> GetGuildChannelsAsync([Path] Snowflake guildId);
         [Post("guilds/{guildId}/channels")]
-        Task<Channel> CreateGuildChannelAsync([Path] Snowflake guildId, [Body] CreateGuildChannelParams args);
+        Task<Channel> CreateGuildChannelAsync([Path] Snowflake guildId, [Body] CreateGuildChannelParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
         [Patch("guilds/{guildId}/channels")]
         Task<Channel[]> ModifyGuildChannelPositionsAsync([Path] Snowflake guildId, [Body] ModifyGuildChannelPositionParams[] args);
 
@@ -153,7 +153,7 @@ namespace Wumpus.Net
         [Put("guilds/{guildId}/members/{userId}")]
         Task<GuildMember> AddGuildMemberAsync([Path] Snowflake guildId, [Path] Snowflake userId, [Body] AddGuildMemberParams args);
         [Delete("guilds/{guildId}/members/{userId}")]
-        Task RemoveGuildMemberAsync([Path] Snowflake guildId, [Path] Snowflake userId);
+        Task RemoveGuildMemberAsync([Path] Snowflake guildId, [Path] Snowflake userId, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
         [Patch("guilds/{guildId}/members/{userId}")]
         Task ModifyGuildMemberAsync([Path] Snowflake guildId, [Path] Snowflake userId, [Body] ModifyGuildMemberParams args);
         [Patch("guilds/{guildId}/members/@me/nick")]
@@ -167,25 +167,25 @@ namespace Wumpus.Net
         [Get("guilds/{guildId}/bans")]
         Task<Ban[]> GetGuildBansAsync([Path] Snowflake guildId);
         [Put("guilds/{guildId}/bans/{userId}")]
-        Task CreateGuildBanAsync([Path] Snowflake guildId, [Path] Snowflake userId, [QueryMap] CreateGuildBanParams args);
+        Task CreateGuildBanAsync([Path] Snowflake guildId, [Path] Snowflake userId, [QueryMap] CreateGuildBanParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
         [Delete("guilds/{guildId}/bans/{userId}")]
-        Task DeleteGuildBanAsync([Path] Snowflake guildId, [Path] Snowflake userId);
+        Task DeleteGuildBanAsync([Path] Snowflake guildId, [Path] Snowflake userId, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
 
         [Get("guilds/{guildId}/roles")]
         Task<Role[]> GetGuildRolesAsync([Path] Snowflake guildId);
         [Post("guilds/{guildId}/roles")]
-        Task<Role> CreateGuildRoleAsync([Path] Snowflake guildId, [Body] CreateGuildRoleParams args);
+        Task<Role> CreateGuildRoleAsync([Path] Snowflake guildId, [Body] CreateGuildRoleParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
         [Delete("guilds/{guildId}/roles/{roleId}")]
-        Task<Role> DeleteGuildRoleAsync([Path] Snowflake guildId, [Path] Snowflake roleId);
+        Task<Role> DeleteGuildRoleAsync([Path] Snowflake guildId, [Path] Snowflake roleId, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
         [Patch("guilds/{guildId}/roles/{roleId}")]
-        Task<Role> ModifyGuildRoleAsync([Path] Snowflake guildId, [Path] Snowflake roleId, [Body] ModifyGuildRoleParams args);
+        Task<Role> ModifyGuildRoleAsync([Path] Snowflake guildId, [Path] Snowflake roleId, [Body] ModifyGuildRoleParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
         [Patch("guilds/{guildId}/roles")]
         Task ModifyGuildRolePositionsAsync([Path] Snowflake guildId, [Body] ModifyGuildRolePositionParams[] args);
 
         [Get("guilds/{guildId}/prune")]
         Task<GuildPruneCountResponse> GetGuildPruneCountAsync([Path] Snowflake guildId, [QueryMap] GuildPruneParams args);
         [Post("guilds/{guildId}/prune")]
-        Task<GuildPruneCountResponse> PruneGuildMembersAsync([Path] Snowflake guildId, [QueryMap] GuildPruneParams args);
+        Task<GuildPruneCountResponse> PruneGuildMembersAsync([Path] Snowflake guildId, [QueryMap] GuildPruneParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
 
         [Get("guilds/{guildId}/regions")]
         Task<VoiceRegion[]> GetGuildVoiceRegionsAsync([Path] Snowflake guildId);
@@ -217,7 +217,7 @@ namespace Wumpus.Net
         [Get("invites/{code}")]
         Task<Invite> GetInviteAsync([Path] Utf8String code, [QueryMap] GetInviteParams args);
         [Delete("invites/{code}")]
-        Task<Invite> DeleteInviteAsync([Path] Utf8String code);
+        Task<Invite> DeleteInviteAsync([Path] Utf8String code, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
 
         // OAuth
 
@@ -265,19 +265,19 @@ namespace Wumpus.Net
         Task<Webhook> GetWebhookAsync([Path] Snowflake webhookId, [Path] Utf8String webhookToken);
 
         [Post("channels/{channelId}/webhooks")]
-        Task<Webhook> CreateWebhookAsync([Path] Snowflake channelId, [Body] CreateWebhookParams args);
+        Task<Webhook> CreateWebhookAsync([Path] Snowflake channelId, [Body] CreateWebhookParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
 
         [Delete("webhooks/{webhookId}")]
-        Task DeleteWebhookAsync([Path] Snowflake webhookId);
+        Task DeleteWebhookAsync([Path] Snowflake webhookId, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
         [Delete("webhooks/{webhookId}/{webhookToken}")]
         [Header("Authorization", null)]
-        Task DeleteWebhookAsync([Path] Snowflake webhookId, [Path] Utf8String webhookToken);
+        Task DeleteWebhookAsync([Path] Snowflake webhookId, [Path] Utf8String webhookToken, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
 
         [Patch("webhooks/{webhookId}")]
-        Task<Webhook> ModifyWebhookAsync([Path] Snowflake webhookId, ModifyWebhookParams args);
+        Task<Webhook> ModifyWebhookAsync([Path] Snowflake webhookId, ModifyWebhookParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
         [Patch("webhooks/{webhookId}/{webhookToken}")]
         [Header("Authorization", null)]
-        Task<Webhook> ModifyWebhookAsync([Path] Snowflake webhookId, [Path] Utf8String webhookToken, ModifyWebhookParams args);
+        Task<Webhook> ModifyWebhookAsync([Path] Snowflake webhookId, [Path] Utf8String webhookToken, ModifyWebhookParams args, [Header(WumpusRestClient.ReasonHeader)] string reason = null);
 
         [Post("webhooks/{webhookId}/{webhookToken}")]
         [Header("Authorization", null)]

--- a/src/Wumpus.Net.Rest/WumpusRestClient.cs
+++ b/src/Wumpus.Net.Rest/WumpusRestClient.cs
@@ -16,6 +16,7 @@ namespace Wumpus
     public class WumpusRestClient : IDiscordRestApi, IDisposable
     {
         public const int ApiVersion = 6;
+        public const string ReasonHeader = "X-Audit-Log-Reason";
         public static string Version { get; } =
             typeof(WumpusRestClient).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ??
             typeof(WumpusRestClient).GetTypeInfo().Assembly.GetName().Version.ToString(3) ??
@@ -64,14 +65,14 @@ namespace Wumpus
             args.Validate();
             return _api.ReplaceChannelAsync(channelId, args);
         }
-        public Task<Channel> ModifyChannelAsync(Snowflake channelId, ModifyChannelParams args)
+        public Task<Channel> ModifyChannelAsync(Snowflake channelId, ModifyChannelParams args, string reason = null)
         {
             Preconditions.NotZero(channelId, nameof(channelId));
             Preconditions.NotNull(args, nameof(args));
             args.Validate();
             return _api.ModifyChannelAsync(channelId, args);
         }
-        public Task<Channel> DeleteChannelAsync(Snowflake channelId)
+        public Task<Channel> DeleteChannelAsync(Snowflake channelId, string reason = null)
         {
             Preconditions.NotZero(channelId, nameof(channelId));
             return _api.DeleteChannelAsync(channelId);
@@ -105,7 +106,7 @@ namespace Wumpus
             args.Validate();
             return _api.ModifyMessageAsync(channelId, messageId, args);
         }
-        public Task DeleteMessageAsync(Snowflake channelId, Snowflake messageId)
+        public Task DeleteMessageAsync(Snowflake channelId, Snowflake messageId, string reason = null)
         {
             Preconditions.NotZero(channelId, nameof(channelId));
             Preconditions.NotZero(messageId, nameof(messageId));
@@ -155,7 +156,7 @@ namespace Wumpus
             return _api.DeleteAllReactionsAsync(channelId, messageId);
         }
 
-        public Task EditChannelPermissionsAsync(Snowflake channelId, Snowflake overwriteId, ModifyChannelPermissionsParams args)
+        public Task EditChannelPermissionsAsync(Snowflake channelId, Snowflake overwriteId, ModifyChannelPermissionsParams args, string reason = null)
         {
             Preconditions.NotZero(channelId, nameof(channelId));
             Preconditions.NotZero(overwriteId, nameof(overwriteId));
@@ -163,7 +164,7 @@ namespace Wumpus
             args.Validate();
             return _api.EditChannelPermissionsAsync(channelId, overwriteId, args);
         }
-        public Task DeleteChannelPermissionsAsync(Snowflake channelId, Snowflake overwriteId)
+        public Task DeleteChannelPermissionsAsync(Snowflake channelId, Snowflake overwriteId, string reason = null)
         {
             Preconditions.NotZero(channelId, nameof(channelId));
             Preconditions.NotZero(overwriteId, nameof(overwriteId));
@@ -235,20 +236,20 @@ namespace Wumpus
             Preconditions.NotZero(emojiId, nameof(emojiId));
             return _api.GetGuildEmojiAsync(guildId, emojiId);
         }
-        public Task<Emoji> CreateGuildEmojiAsync(Snowflake guildId, CreateGuildEmojiParams args)
+        public Task<Emoji> CreateGuildEmojiAsync(Snowflake guildId, CreateGuildEmojiParams args, string reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotNull(args, nameof(args));
             return _api.CreateGuildEmojiAsync(guildId, args);
         }
-        public Task<Emoji> ModifyGuildEmojiAsync(Snowflake guildId, Snowflake emojiId, ModifyGuildEmojiParams args)
+        public Task<Emoji> ModifyGuildEmojiAsync(Snowflake guildId, Snowflake emojiId, ModifyGuildEmojiParams args, string reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(emojiId, nameof(emojiId));
             Preconditions.NotNull(args, nameof(args));
             return _api.ModifyGuildEmojiAsync(guildId, emojiId, args);
         }
-        public Task DeleteGuildEmojiAsync(Snowflake guildId, Snowflake emojiId)
+        public Task DeleteGuildEmojiAsync(Snowflake guildId, Snowflake emojiId, string reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(emojiId, nameof(emojiId));
@@ -279,7 +280,7 @@ namespace Wumpus
             args.Validate();
             return _api.CreateGuildAsync(args);
         }
-        public Task<Guild> ModifyGuildAsync(Snowflake guildId, ModifyGuildParams args)
+        public Task<Guild> ModifyGuildAsync(Snowflake guildId, ModifyGuildParams args, string reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotNull(args, nameof(args));
@@ -297,7 +298,7 @@ namespace Wumpus
             Preconditions.NotZero(guildId, nameof(guildId));
             return _api.GetGuildChannelsAsync(guildId);
         }
-        public Task<Channel> CreateGuildChannelAsync(Snowflake guildId, CreateGuildChannelParams args)
+        public Task<Channel> CreateGuildChannelAsync(Snowflake guildId, CreateGuildChannelParams args, string reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotNull(args, nameof(args));
@@ -334,7 +335,7 @@ namespace Wumpus
             args.Validate();
             return _api.AddGuildMemberAsync(guildId, userId, args);
         }
-        public Task RemoveGuildMemberAsync(Snowflake guildId, Snowflake userId)
+        public Task RemoveGuildMemberAsync(Snowflake guildId, Snowflake userId, string reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(userId, nameof(userId));
@@ -376,7 +377,7 @@ namespace Wumpus
             Preconditions.NotZero(guildId, nameof(guildId));
             return _api.GetGuildBansAsync(guildId);
         }
-        public Task CreateGuildBanAsync(Snowflake guildId, Snowflake userId, CreateGuildBanParams args)
+        public Task CreateGuildBanAsync(Snowflake guildId, Snowflake userId, CreateGuildBanParams args, string reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(userId, nameof(userId));
@@ -384,7 +385,7 @@ namespace Wumpus
             args.Validate();
             return _api.CreateGuildBanAsync(guildId, userId, args);
         }
-        public Task DeleteGuildBanAsync(Snowflake guildId, Snowflake userId)
+        public Task DeleteGuildBanAsync(Snowflake guildId, Snowflake userId, string reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(userId, nameof(userId));
@@ -396,20 +397,20 @@ namespace Wumpus
             Preconditions.NotZero(guildId, nameof(guildId));
             return _api.GetGuildRolesAsync(guildId);
         }
-        public Task<Role> CreateGuildRoleAsync(Snowflake guildId, CreateGuildRoleParams args)
+        public Task<Role> CreateGuildRoleAsync(Snowflake guildId, CreateGuildRoleParams args, string reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotNull(args, nameof(args));
             args.Validate();
             return _api.CreateGuildRoleAsync(guildId, args);
         }
-        public Task<Role> DeleteGuildRoleAsync(Snowflake guildId, Snowflake roleId)
+        public Task<Role> DeleteGuildRoleAsync(Snowflake guildId, Snowflake roleId, string reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(roleId, nameof(roleId));
             return _api.DeleteGuildRoleAsync(guildId, roleId);
         }
-        public Task<Role> ModifyGuildRoleAsync(Snowflake guildId, Snowflake roleId, ModifyGuildRoleParams args)
+        public Task<Role> ModifyGuildRoleAsync(Snowflake guildId, Snowflake roleId, ModifyGuildRoleParams args, string reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(roleId, nameof(roleId));
@@ -433,7 +434,7 @@ namespace Wumpus
             args.Validate();
             return _api.GetGuildPruneCountAsync(guildId, args);
         }
-        public Task<GuildPruneCountResponse> PruneGuildMembersAsync(Snowflake guildId, GuildPruneParams args)
+        public Task<GuildPruneCountResponse> PruneGuildMembersAsync(Snowflake guildId, GuildPruneParams args, string reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotNull(args, nameof(args));
@@ -514,7 +515,7 @@ namespace Wumpus
             args.Validate();
             return _api.GetInviteAsync(code, args);
         }
-        public Task<Invite> DeleteInviteAsync(Utf8String code)
+        public Task<Invite> DeleteInviteAsync(Utf8String code, string reason = null)
         {
             Preconditions.NotNullOrWhitespace(code, nameof(code));
             return _api.DeleteInviteAsync(code);
@@ -598,7 +599,7 @@ namespace Wumpus
             return _api.GetWebhookAsync(webhookId, webhookToken);
         }
 
-        public Task<Webhook> CreateWebhookAsync(Snowflake channelId, CreateWebhookParams args)
+        public Task<Webhook> CreateWebhookAsync(Snowflake channelId, CreateWebhookParams args, string reason = null)
         {
             Preconditions.NotZero(channelId, nameof(channelId));
             Preconditions.NotNull(args, nameof(args));
@@ -606,26 +607,26 @@ namespace Wumpus
             return _api.CreateWebhookAsync(channelId, args);
         }
 
-        public Task DeleteWebhookAsync(Snowflake webhookId)
+        public Task DeleteWebhookAsync(Snowflake webhookId, string reason = null)
         {
             Preconditions.NotZero(webhookId, nameof(webhookId));
             return _api.DeleteWebhookAsync(webhookId);
         }
-        public Task DeleteWebhookAsync(Snowflake webhookId, Utf8String webhookToken)
+        public Task DeleteWebhookAsync(Snowflake webhookId, Utf8String webhookToken, string reason = null)
         {
             Preconditions.NotZero(webhookId, nameof(webhookId));
             Preconditions.NotNullOrWhitespace(webhookToken, nameof(webhookToken));
             return _api.DeleteWebhookAsync(webhookId, webhookToken);
         }
 
-        public Task<Webhook> ModifyWebhookAsync(Snowflake webhookId, ModifyWebhookParams args)
+        public Task<Webhook> ModifyWebhookAsync(Snowflake webhookId, ModifyWebhookParams args, string reason = null)
         {
             Preconditions.NotZero(webhookId, nameof(webhookId));
             Preconditions.NotNull(args, nameof(args));
             args.Validate();
             return _api.ModifyWebhookAsync(webhookId, args);
         }
-        public Task<Webhook> ModifyWebhookAsync(Snowflake webhookId, Utf8String webhookToken, ModifyWebhookParams args)
+        public Task<Webhook> ModifyWebhookAsync(Snowflake webhookId, Utf8String webhookToken, ModifyWebhookParams args, string reason = null)
         {
             Preconditions.NotZero(webhookId, nameof(webhookId));
             Preconditions.NotNullOrWhitespace(webhookToken, nameof(webhookToken));

--- a/src/Wumpus.Net.Rest/WumpusRestClient.cs
+++ b/src/Wumpus.Net.Rest/WumpusRestClient.cs
@@ -17,6 +17,10 @@ namespace Wumpus
     {
         public const int ApiVersion = 6;
         public const string ReasonHeader = "X-Audit-Log-Reason";
+        /// <summary>
+        ///     The maximum valid length of the audit log reason string.
+        /// </summary>
+        public const int MaxReasonHeaderLength = 512;
         public static string Version { get; } =
             typeof(WumpusRestClient).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ??
             typeof(WumpusRestClient).GetTypeInfo().Assembly.GetName().Version.ToString(3) ??
@@ -69,12 +73,14 @@ namespace Wumpus
         {
             Preconditions.NotZero(channelId, nameof(channelId));
             Preconditions.NotNull(args, nameof(args));
+            Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             args.Validate();
             return _api.ModifyChannelAsync(channelId, args, reason);
         }
         public Task<Channel> DeleteChannelAsync(Snowflake channelId, string reason = null)
         {
             Preconditions.NotZero(channelId, nameof(channelId));
+            Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             return _api.DeleteChannelAsync(channelId, reason);
         }
 
@@ -110,6 +116,7 @@ namespace Wumpus
         {
             Preconditions.NotZero(channelId, nameof(channelId));
             Preconditions.NotZero(messageId, nameof(messageId));
+            Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             return _api.DeleteMessageAsync(channelId, messageId, reason);
         }
         public Task DeleteMessagesAsync(Snowflake channelId, DeleteMessagesParams args)
@@ -161,6 +168,7 @@ namespace Wumpus
             Preconditions.NotZero(channelId, nameof(channelId));
             Preconditions.NotZero(overwriteId, nameof(overwriteId));
             Preconditions.NotNull(args, nameof(args));
+            Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             args.Validate();
             return _api.EditChannelPermissionsAsync(channelId, overwriteId, args, reason);
         }
@@ -168,6 +176,7 @@ namespace Wumpus
         {
             Preconditions.NotZero(channelId, nameof(channelId));
             Preconditions.NotZero(overwriteId, nameof(overwriteId));
+            Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             return _api.DeleteChannelPermissionsAsync(channelId, overwriteId, reason);
         }
 
@@ -240,6 +249,7 @@ namespace Wumpus
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotNull(args, nameof(args));
+            Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             return _api.CreateGuildEmojiAsync(guildId, args, reason);
         }
         public Task<Emoji> ModifyGuildEmojiAsync(Snowflake guildId, Snowflake emojiId, ModifyGuildEmojiParams args, string reason = null)
@@ -247,12 +257,14 @@ namespace Wumpus
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(emojiId, nameof(emojiId));
             Preconditions.NotNull(args, nameof(args));
+            Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             return _api.ModifyGuildEmojiAsync(guildId, emojiId, args, reason);
         }
         public Task DeleteGuildEmojiAsync(Snowflake guildId, Snowflake emojiId, string reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(emojiId, nameof(emojiId));
+            Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             return _api.DeleteGuildEmojiAsync(guildId, emojiId, reason);
         }
 
@@ -284,6 +296,7 @@ namespace Wumpus
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotNull(args, nameof(args));
+            Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             args.Validate();
             return _api.ModifyGuildAsync(guildId, args, reason);
         }
@@ -302,6 +315,7 @@ namespace Wumpus
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotNull(args, nameof(args));
+            Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             args.Validate();
             return _api.CreateGuildChannelAsync(guildId, args, reason);
         }
@@ -339,6 +353,7 @@ namespace Wumpus
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(userId, nameof(userId));
+            Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             return _api.RemoveGuildMemberAsync(guildId, userId, reason);
         }
         public Task ModifyGuildMemberAsync(Snowflake guildId, Snowflake userId, ModifyGuildMemberParams args)
@@ -382,6 +397,7 @@ namespace Wumpus
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(userId, nameof(userId));
             Preconditions.NotNull(args, nameof(args));
+            Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             args.Validate();
             return _api.CreateGuildBanAsync(guildId, userId, args, reason);
         }
@@ -389,6 +405,7 @@ namespace Wumpus
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(userId, nameof(userId));
+            Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             return _api.DeleteGuildBanAsync(guildId, userId, reason);
         }
 
@@ -401,6 +418,7 @@ namespace Wumpus
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotNull(args, nameof(args));
+            Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             args.Validate();
             return _api.CreateGuildRoleAsync(guildId, args, reason);
         }
@@ -408,6 +426,7 @@ namespace Wumpus
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(roleId, nameof(roleId));
+            Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             return _api.DeleteGuildRoleAsync(guildId, roleId, reason);
         }
         public Task<Role> ModifyGuildRoleAsync(Snowflake guildId, Snowflake roleId, ModifyGuildRoleParams args, string reason = null)
@@ -415,6 +434,7 @@ namespace Wumpus
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(roleId, nameof(roleId));
             Preconditions.NotNull(args, nameof(args));
+            Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             args.Validate();
             return _api.ModifyGuildRoleAsync(guildId, roleId, args, reason);
         }
@@ -438,6 +458,7 @@ namespace Wumpus
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotNull(args, nameof(args));
+            Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             args.Validate();
             return _api.PruneGuildMembersAsync(guildId, args, reason);
         }
@@ -518,6 +539,7 @@ namespace Wumpus
         public Task<Invite> DeleteInviteAsync(Utf8String code, string reason = null)
         {
             Preconditions.NotNullOrWhitespace(code, nameof(code));
+            Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             return _api.DeleteInviteAsync(code, reason);
         }
 
@@ -603,6 +625,7 @@ namespace Wumpus
         {
             Preconditions.NotZero(channelId, nameof(channelId));
             Preconditions.NotNull(args, nameof(args));
+            Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             args.Validate();
             return _api.CreateWebhookAsync(channelId, args, reason);
         }
@@ -610,12 +633,14 @@ namespace Wumpus
         public Task DeleteWebhookAsync(Snowflake webhookId, string reason = null)
         {
             Preconditions.NotZero(webhookId, nameof(webhookId));
+            Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             return _api.DeleteWebhookAsync(webhookId, reason);
         }
         public Task DeleteWebhookAsync(Snowflake webhookId, Utf8String webhookToken, string reason = null)
         {
             Preconditions.NotZero(webhookId, nameof(webhookId));
             Preconditions.NotNullOrWhitespace(webhookToken, nameof(webhookToken));
+            Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             return _api.DeleteWebhookAsync(webhookId, webhookToken, reason);
         }
 
@@ -623,6 +648,7 @@ namespace Wumpus
         {
             Preconditions.NotZero(webhookId, nameof(webhookId));
             Preconditions.NotNull(args, nameof(args));
+            Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             args.Validate();
             return _api.ModifyWebhookAsync(webhookId, args, reason);
         }
@@ -631,6 +657,7 @@ namespace Wumpus
             Preconditions.NotZero(webhookId, nameof(webhookId));
             Preconditions.NotNullOrWhitespace(webhookToken, nameof(webhookToken));
             Preconditions.NotNull(args, nameof(args));
+            Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             args.Validate();
             return _api.ModifyWebhookAsync(webhookId, webhookToken, args, reason);
         }

--- a/src/Wumpus.Net.Rest/WumpusRestClient.cs
+++ b/src/Wumpus.Net.Rest/WumpusRestClient.cs
@@ -69,7 +69,7 @@ namespace Wumpus
             args.Validate();
             return _api.ReplaceChannelAsync(channelId, args);
         }
-        public Task<Channel> ModifyChannelAsync(Snowflake channelId, ModifyChannelParams args, string reason = null)
+        public Task<Channel> ModifyChannelAsync(Snowflake channelId, ModifyChannelParams args, Utf8String reason = null)
         {
             Preconditions.NotZero(channelId, nameof(channelId));
             Preconditions.NotNull(args, nameof(args));
@@ -77,7 +77,7 @@ namespace Wumpus
             args.Validate();
             return _api.ModifyChannelAsync(channelId, args, reason);
         }
-        public Task<Channel> DeleteChannelAsync(Snowflake channelId, string reason = null)
+        public Task<Channel> DeleteChannelAsync(Snowflake channelId, Utf8String reason = null)
         {
             Preconditions.NotZero(channelId, nameof(channelId));
             Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
@@ -112,7 +112,7 @@ namespace Wumpus
             args.Validate();
             return _api.ModifyMessageAsync(channelId, messageId, args);
         }
-        public Task DeleteMessageAsync(Snowflake channelId, Snowflake messageId, string reason = null)
+        public Task DeleteMessageAsync(Snowflake channelId, Snowflake messageId, Utf8String reason = null)
         {
             Preconditions.NotZero(channelId, nameof(channelId));
             Preconditions.NotZero(messageId, nameof(messageId));
@@ -163,7 +163,7 @@ namespace Wumpus
             return _api.DeleteAllReactionsAsync(channelId, messageId);
         }
 
-        public Task EditChannelPermissionsAsync(Snowflake channelId, Snowflake overwriteId, ModifyChannelPermissionsParams args, string reason = null)
+        public Task EditChannelPermissionsAsync(Snowflake channelId, Snowflake overwriteId, ModifyChannelPermissionsParams args, Utf8String reason = null)
         {
             Preconditions.NotZero(channelId, nameof(channelId));
             Preconditions.NotZero(overwriteId, nameof(overwriteId));
@@ -172,7 +172,7 @@ namespace Wumpus
             args.Validate();
             return _api.EditChannelPermissionsAsync(channelId, overwriteId, args, reason);
         }
-        public Task DeleteChannelPermissionsAsync(Snowflake channelId, Snowflake overwriteId, string reason = null)
+        public Task DeleteChannelPermissionsAsync(Snowflake channelId, Snowflake overwriteId, Utf8String reason = null)
         {
             Preconditions.NotZero(channelId, nameof(channelId));
             Preconditions.NotZero(overwriteId, nameof(overwriteId));
@@ -245,14 +245,14 @@ namespace Wumpus
             Preconditions.NotZero(emojiId, nameof(emojiId));
             return _api.GetGuildEmojiAsync(guildId, emojiId);
         }
-        public Task<Emoji> CreateGuildEmojiAsync(Snowflake guildId, CreateGuildEmojiParams args, string reason = null)
+        public Task<Emoji> CreateGuildEmojiAsync(Snowflake guildId, CreateGuildEmojiParams args, Utf8String reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotNull(args, nameof(args));
             Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             return _api.CreateGuildEmojiAsync(guildId, args, reason);
         }
-        public Task<Emoji> ModifyGuildEmojiAsync(Snowflake guildId, Snowflake emojiId, ModifyGuildEmojiParams args, string reason = null)
+        public Task<Emoji> ModifyGuildEmojiAsync(Snowflake guildId, Snowflake emojiId, ModifyGuildEmojiParams args, Utf8String reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(emojiId, nameof(emojiId));
@@ -260,7 +260,7 @@ namespace Wumpus
             Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             return _api.ModifyGuildEmojiAsync(guildId, emojiId, args, reason);
         }
-        public Task DeleteGuildEmojiAsync(Snowflake guildId, Snowflake emojiId, string reason = null)
+        public Task DeleteGuildEmojiAsync(Snowflake guildId, Snowflake emojiId, Utf8String reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(emojiId, nameof(emojiId));
@@ -292,7 +292,7 @@ namespace Wumpus
             args.Validate();
             return _api.CreateGuildAsync(args);
         }
-        public Task<Guild> ModifyGuildAsync(Snowflake guildId, ModifyGuildParams args, string reason = null)
+        public Task<Guild> ModifyGuildAsync(Snowflake guildId, ModifyGuildParams args, Utf8String reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotNull(args, nameof(args));
@@ -311,7 +311,7 @@ namespace Wumpus
             Preconditions.NotZero(guildId, nameof(guildId));
             return _api.GetGuildChannelsAsync(guildId);
         }
-        public Task<Channel> CreateGuildChannelAsync(Snowflake guildId, CreateGuildChannelParams args, string reason = null)
+        public Task<Channel> CreateGuildChannelAsync(Snowflake guildId, CreateGuildChannelParams args, Utf8String reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotNull(args, nameof(args));
@@ -349,7 +349,7 @@ namespace Wumpus
             args.Validate();
             return _api.AddGuildMemberAsync(guildId, userId, args);
         }
-        public Task RemoveGuildMemberAsync(Snowflake guildId, Snowflake userId, string reason = null)
+        public Task RemoveGuildMemberAsync(Snowflake guildId, Snowflake userId, Utf8String reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(userId, nameof(userId));
@@ -392,7 +392,7 @@ namespace Wumpus
             Preconditions.NotZero(guildId, nameof(guildId));
             return _api.GetGuildBansAsync(guildId);
         }
-        public Task CreateGuildBanAsync(Snowflake guildId, Snowflake userId, CreateGuildBanParams args, string reason = null)
+        public Task CreateGuildBanAsync(Snowflake guildId, Snowflake userId, CreateGuildBanParams args, Utf8String reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(userId, nameof(userId));
@@ -401,7 +401,7 @@ namespace Wumpus
             args.Validate();
             return _api.CreateGuildBanAsync(guildId, userId, args, reason);
         }
-        public Task DeleteGuildBanAsync(Snowflake guildId, Snowflake userId, string reason = null)
+        public Task DeleteGuildBanAsync(Snowflake guildId, Snowflake userId, Utf8String reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(userId, nameof(userId));
@@ -414,7 +414,7 @@ namespace Wumpus
             Preconditions.NotZero(guildId, nameof(guildId));
             return _api.GetGuildRolesAsync(guildId);
         }
-        public Task<Role> CreateGuildRoleAsync(Snowflake guildId, CreateGuildRoleParams args, string reason = null)
+        public Task<Role> CreateGuildRoleAsync(Snowflake guildId, CreateGuildRoleParams args, Utf8String reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotNull(args, nameof(args));
@@ -422,14 +422,14 @@ namespace Wumpus
             args.Validate();
             return _api.CreateGuildRoleAsync(guildId, args, reason);
         }
-        public Task<Role> DeleteGuildRoleAsync(Snowflake guildId, Snowflake roleId, string reason = null)
+        public Task<Role> DeleteGuildRoleAsync(Snowflake guildId, Snowflake roleId, Utf8String reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(roleId, nameof(roleId));
             Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             return _api.DeleteGuildRoleAsync(guildId, roleId, reason);
         }
-        public Task<Role> ModifyGuildRoleAsync(Snowflake guildId, Snowflake roleId, ModifyGuildRoleParams args, string reason = null)
+        public Task<Role> ModifyGuildRoleAsync(Snowflake guildId, Snowflake roleId, ModifyGuildRoleParams args, Utf8String reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(roleId, nameof(roleId));
@@ -454,7 +454,7 @@ namespace Wumpus
             args.Validate();
             return _api.GetGuildPruneCountAsync(guildId, args);
         }
-        public Task<GuildPruneCountResponse> PruneGuildMembersAsync(Snowflake guildId, GuildPruneParams args, string reason = null)
+        public Task<GuildPruneCountResponse> PruneGuildMembersAsync(Snowflake guildId, GuildPruneParams args, Utf8String reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotNull(args, nameof(args));
@@ -536,7 +536,7 @@ namespace Wumpus
             args.Validate();
             return _api.GetInviteAsync(code, args);
         }
-        public Task<Invite> DeleteInviteAsync(Utf8String code, string reason = null)
+        public Task<Invite> DeleteInviteAsync(Utf8String code, Utf8String reason = null)
         {
             Preconditions.NotNullOrWhitespace(code, nameof(code));
             Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
@@ -621,7 +621,7 @@ namespace Wumpus
             return _api.GetWebhookAsync(webhookId, webhookToken);
         }
 
-        public Task<Webhook> CreateWebhookAsync(Snowflake channelId, CreateWebhookParams args, string reason = null)
+        public Task<Webhook> CreateWebhookAsync(Snowflake channelId, CreateWebhookParams args, Utf8String reason = null)
         {
             Preconditions.NotZero(channelId, nameof(channelId));
             Preconditions.NotNull(args, nameof(args));
@@ -630,13 +630,13 @@ namespace Wumpus
             return _api.CreateWebhookAsync(channelId, args, reason);
         }
 
-        public Task DeleteWebhookAsync(Snowflake webhookId, string reason = null)
+        public Task DeleteWebhookAsync(Snowflake webhookId, Utf8String reason = null)
         {
             Preconditions.NotZero(webhookId, nameof(webhookId));
             Preconditions.LengthLessThan(reason, MaxReasonHeaderLength, nameof(reason));
             return _api.DeleteWebhookAsync(webhookId, reason);
         }
-        public Task DeleteWebhookAsync(Snowflake webhookId, Utf8String webhookToken, string reason = null)
+        public Task DeleteWebhookAsync(Snowflake webhookId, Utf8String webhookToken, Utf8String reason = null)
         {
             Preconditions.NotZero(webhookId, nameof(webhookId));
             Preconditions.NotNullOrWhitespace(webhookToken, nameof(webhookToken));
@@ -644,7 +644,7 @@ namespace Wumpus
             return _api.DeleteWebhookAsync(webhookId, webhookToken, reason);
         }
 
-        public Task<Webhook> ModifyWebhookAsync(Snowflake webhookId, ModifyWebhookParams args, string reason = null)
+        public Task<Webhook> ModifyWebhookAsync(Snowflake webhookId, ModifyWebhookParams args, Utf8String reason = null)
         {
             Preconditions.NotZero(webhookId, nameof(webhookId));
             Preconditions.NotNull(args, nameof(args));
@@ -652,7 +652,7 @@ namespace Wumpus
             args.Validate();
             return _api.ModifyWebhookAsync(webhookId, args, reason);
         }
-        public Task<Webhook> ModifyWebhookAsync(Snowflake webhookId, Utf8String webhookToken, ModifyWebhookParams args, string reason = null)
+        public Task<Webhook> ModifyWebhookAsync(Snowflake webhookId, Utf8String webhookToken, ModifyWebhookParams args, Utf8String reason = null)
         {
             Preconditions.NotZero(webhookId, nameof(webhookId));
             Preconditions.NotNullOrWhitespace(webhookToken, nameof(webhookToken));

--- a/src/Wumpus.Net.Rest/WumpusRestClient.cs
+++ b/src/Wumpus.Net.Rest/WumpusRestClient.cs
@@ -18,7 +18,7 @@ namespace Wumpus
         public const int ApiVersion = 6;
         public const string ReasonHeader = "X-Audit-Log-Reason";
         /// <summary>
-        ///     The maximum valid length of the audit log reason string.
+        ///     The maximum valid length of the audit log reason header string.
         /// </summary>
         public const int MaxReasonHeaderLength = 512;
         public static string Version { get; } =

--- a/src/Wumpus.Net.Rest/WumpusRestClient.cs
+++ b/src/Wumpus.Net.Rest/WumpusRestClient.cs
@@ -70,12 +70,12 @@ namespace Wumpus
             Preconditions.NotZero(channelId, nameof(channelId));
             Preconditions.NotNull(args, nameof(args));
             args.Validate();
-            return _api.ModifyChannelAsync(channelId, args);
+            return _api.ModifyChannelAsync(channelId, args, reason);
         }
         public Task<Channel> DeleteChannelAsync(Snowflake channelId, string reason = null)
         {
             Preconditions.NotZero(channelId, nameof(channelId));
-            return _api.DeleteChannelAsync(channelId);
+            return _api.DeleteChannelAsync(channelId, reason);
         }
 
         public Task<Message[]> GetChannelMessagesAsync(Snowflake channelId, GetChannelMessagesParams args)
@@ -110,7 +110,7 @@ namespace Wumpus
         {
             Preconditions.NotZero(channelId, nameof(channelId));
             Preconditions.NotZero(messageId, nameof(messageId));
-            return _api.DeleteMessageAsync(channelId, messageId);
+            return _api.DeleteMessageAsync(channelId, messageId, reason);
         }
         public Task DeleteMessagesAsync(Snowflake channelId, DeleteMessagesParams args)
         {
@@ -162,13 +162,13 @@ namespace Wumpus
             Preconditions.NotZero(overwriteId, nameof(overwriteId));
             Preconditions.NotNull(args, nameof(args));
             args.Validate();
-            return _api.EditChannelPermissionsAsync(channelId, overwriteId, args);
+            return _api.EditChannelPermissionsAsync(channelId, overwriteId, args, reason);
         }
         public Task DeleteChannelPermissionsAsync(Snowflake channelId, Snowflake overwriteId, string reason = null)
         {
             Preconditions.NotZero(channelId, nameof(channelId));
             Preconditions.NotZero(overwriteId, nameof(overwriteId));
-            return _api.DeleteChannelPermissionsAsync(channelId, overwriteId);
+            return _api.DeleteChannelPermissionsAsync(channelId, overwriteId, reason);
         }
 
         public Task<Invite[]> GetChannelInvitesAsync(Snowflake channelId)
@@ -240,20 +240,20 @@ namespace Wumpus
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotNull(args, nameof(args));
-            return _api.CreateGuildEmojiAsync(guildId, args);
+            return _api.CreateGuildEmojiAsync(guildId, args, reason);
         }
         public Task<Emoji> ModifyGuildEmojiAsync(Snowflake guildId, Snowflake emojiId, ModifyGuildEmojiParams args, string reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(emojiId, nameof(emojiId));
             Preconditions.NotNull(args, nameof(args));
-            return _api.ModifyGuildEmojiAsync(guildId, emojiId, args);
+            return _api.ModifyGuildEmojiAsync(guildId, emojiId, args, reason);
         }
         public Task DeleteGuildEmojiAsync(Snowflake guildId, Snowflake emojiId, string reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(emojiId, nameof(emojiId));
-            return _api.DeleteGuildEmojiAsync(guildId, emojiId);
+            return _api.DeleteGuildEmojiAsync(guildId, emojiId, reason);
         }
 
         // Gateway
@@ -285,7 +285,7 @@ namespace Wumpus
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotNull(args, nameof(args));
             args.Validate();
-            return _api.ModifyGuildAsync(guildId, args);
+            return _api.ModifyGuildAsync(guildId, args, reason);
         }
         public Task DeleteGuildAsync(Snowflake guildId)
         {
@@ -303,7 +303,7 @@ namespace Wumpus
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotNull(args, nameof(args));
             args.Validate();
-            return _api.CreateGuildChannelAsync(guildId, args);
+            return _api.CreateGuildChannelAsync(guildId, args, reason);
         }
         public Task<Channel[]> ModifyGuildChannelPositionsAsync(Snowflake guildId, ModifyGuildChannelPositionParams[] args)
         {
@@ -339,7 +339,7 @@ namespace Wumpus
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(userId, nameof(userId));
-            return _api.RemoveGuildMemberAsync(guildId, userId);
+            return _api.RemoveGuildMemberAsync(guildId, userId, reason);
         }
         public Task ModifyGuildMemberAsync(Snowflake guildId, Snowflake userId, ModifyGuildMemberParams args)
         {
@@ -383,13 +383,13 @@ namespace Wumpus
             Preconditions.NotZero(userId, nameof(userId));
             Preconditions.NotNull(args, nameof(args));
             args.Validate();
-            return _api.CreateGuildBanAsync(guildId, userId, args);
+            return _api.CreateGuildBanAsync(guildId, userId, args, reason);
         }
         public Task DeleteGuildBanAsync(Snowflake guildId, Snowflake userId, string reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(userId, nameof(userId));
-            return _api.DeleteGuildBanAsync(guildId, userId);
+            return _api.DeleteGuildBanAsync(guildId, userId, reason);
         }
 
         public Task<Role[]> GetGuildRolesAsync(Snowflake guildId)
@@ -402,13 +402,13 @@ namespace Wumpus
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotNull(args, nameof(args));
             args.Validate();
-            return _api.CreateGuildRoleAsync(guildId, args);
+            return _api.CreateGuildRoleAsync(guildId, args, reason);
         }
         public Task<Role> DeleteGuildRoleAsync(Snowflake guildId, Snowflake roleId, string reason = null)
         {
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotZero(roleId, nameof(roleId));
-            return _api.DeleteGuildRoleAsync(guildId, roleId);
+            return _api.DeleteGuildRoleAsync(guildId, roleId, reason);
         }
         public Task<Role> ModifyGuildRoleAsync(Snowflake guildId, Snowflake roleId, ModifyGuildRoleParams args, string reason = null)
         {
@@ -416,7 +416,7 @@ namespace Wumpus
             Preconditions.NotZero(roleId, nameof(roleId));
             Preconditions.NotNull(args, nameof(args));
             args.Validate();
-            return _api.ModifyGuildRoleAsync(guildId, roleId, args);
+            return _api.ModifyGuildRoleAsync(guildId, roleId, args, reason);
         }
         public Task ModifyGuildRolePositionsAsync(Snowflake guildId, ModifyGuildRolePositionParams[] args)
         {
@@ -439,7 +439,7 @@ namespace Wumpus
             Preconditions.NotZero(guildId, nameof(guildId));
             Preconditions.NotNull(args, nameof(args));
             args.Validate();
-            return _api.PruneGuildMembersAsync(guildId, args);
+            return _api.PruneGuildMembersAsync(guildId, args, reason);
         }
 
         public Task<VoiceRegion[]> GetGuildVoiceRegionsAsync(Snowflake guildId)
@@ -518,7 +518,7 @@ namespace Wumpus
         public Task<Invite> DeleteInviteAsync(Utf8String code, string reason = null)
         {
             Preconditions.NotNullOrWhitespace(code, nameof(code));
-            return _api.DeleteInviteAsync(code);
+            return _api.DeleteInviteAsync(code, reason);
         }
 
         // User
@@ -604,19 +604,19 @@ namespace Wumpus
             Preconditions.NotZero(channelId, nameof(channelId));
             Preconditions.NotNull(args, nameof(args));
             args.Validate();
-            return _api.CreateWebhookAsync(channelId, args);
+            return _api.CreateWebhookAsync(channelId, args, reason);
         }
 
         public Task DeleteWebhookAsync(Snowflake webhookId, string reason = null)
         {
             Preconditions.NotZero(webhookId, nameof(webhookId));
-            return _api.DeleteWebhookAsync(webhookId);
+            return _api.DeleteWebhookAsync(webhookId, reason);
         }
         public Task DeleteWebhookAsync(Snowflake webhookId, Utf8String webhookToken, string reason = null)
         {
             Preconditions.NotZero(webhookId, nameof(webhookId));
             Preconditions.NotNullOrWhitespace(webhookToken, nameof(webhookToken));
-            return _api.DeleteWebhookAsync(webhookId, webhookToken);
+            return _api.DeleteWebhookAsync(webhookId, webhookToken, reason);
         }
 
         public Task<Webhook> ModifyWebhookAsync(Snowflake webhookId, ModifyWebhookParams args, string reason = null)
@@ -624,7 +624,7 @@ namespace Wumpus
             Preconditions.NotZero(webhookId, nameof(webhookId));
             Preconditions.NotNull(args, nameof(args));
             args.Validate();
-            return _api.ModifyWebhookAsync(webhookId, args);
+            return _api.ModifyWebhookAsync(webhookId, args, reason);
         }
         public Task<Webhook> ModifyWebhookAsync(Snowflake webhookId, Utf8String webhookToken, ModifyWebhookParams args, string reason = null)
         {
@@ -632,7 +632,7 @@ namespace Wumpus
             Preconditions.NotNullOrWhitespace(webhookToken, nameof(webhookToken));
             Preconditions.NotNull(args, nameof(args));
             args.Validate();
-            return _api.ModifyWebhookAsync(webhookId, webhookToken, args);
+            return _api.ModifyWebhookAsync(webhookId, webhookToken, args, reason);
         }
 
         public Task ExecuteWebhookAsync(Snowflake webhookId, Utf8String webhookToken, ExecuteWebhookParams args)


### PR DESCRIPTION
Fix #11 

This adds an optional `reason` parameter to all relevant methods (those with corresponding event Audit Log event types) to the rest API tasks. When this parameter is not null, it's value will be included as part of this header.

I had questions about a few implementation details:
- Should this header be an option for _all_ rest endpoints, not just these?
- Given the current tests, I'm not sure of a great way to test that this header is included. I was able to debug that the controller did receive this header when it was not null.
